### PR TITLE
Pinning covalent-aws-plugins to 0.1.0rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updated requirements.txt to pin aws executor plugins to pre-release version 0.1.0rc0
+
 ## [0.5.0] - 2022-09-15
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 amazon-braket-pennylane-plugin==1.6.9
 boto3==1.24.35
-git+https://github.com/AgnostiqHQ/covalent.git@develop#egg=covalent
-git+https://github.com/AgnostiqHQ/covalent-aws-plugins.git@develop#egg=covalent-aws-plugins
+covalent-aws-plugins==0.1.0rc0
 docker==5.0.3


### PR DESCRIPTION
Pinning covalent-aws-plugins to 0.1.0rc0
Removed explicit covalent dependency

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
