### PR TITLE
Updates to executor base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Changed
+
+- Updated Dockerfile to contain `COVALENT_BASE_IMAGE` ARG
+- Removed explicit cloudpickle install due to version conflict with covalent cloudpickle from Dockerfile
+- Constrained covalent semver range to be less than major version 1 for this version of Dockerfile
+
 ## [0.8.0] - 2022-10-25
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM amd64/python:3.8-slim-buster
+ARG COVALENT_BASE_IMAGE
+FROM ${COVALENT_BASE_IMAGE}
 
 RUN apt-get update && apt-get install -y \
   rsync \
@@ -8,11 +9,10 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir --use-feature=in-tree-build --upgrade \
   amazon-braket-pennylane-plugin==1.6.9 \
   boto3==1.20.48 \
-  cloudpickle==2.0.0 \
   pennylane==0.24.0 \
   sagemaker-training
 
-RUN pip install covalent
+RUN pip install "covalent>=0.202.0,<1"
 
 WORKDIR /opt/ml/code
 COPY covalent_braket_plugin/exec.py /opt/ml/code


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.

Changes:
- Updated Dockerfile to contain `COVALENT_BASE_IMAGE` ARG
- Removed explicit cloudpickle install due to version conflict with covalent cloudpickle from Dockerfile
- Constrained covalent semver range to be less than major version 1 for this version of Dockerfile